### PR TITLE
Add cipher suites to get an "A" on SSL Labs test.

### DIFF
--- a/core/Network/TLS/Extra/Cipher.hs
+++ b/core/Network/TLS/Extra/Cipher.hs
@@ -385,6 +385,7 @@ cipher_ECDHE_RSA_AES128CBC_SHA = Cipher
     , cipherBulk         = bulk_aes128
     , cipherHash         = SHA1
     , cipherKeyExchange  = CipherKeyExchange_ECDHE_RSA
+    , cipherMinVer       = Just TLS10
     }
 
 --TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 

--- a/core/Network/TLS/Extra/Cipher.hs
+++ b/core/Network/TLS/Extra/Cipher.hs
@@ -35,6 +35,8 @@ module Network.TLS.Extra.Cipher
     , cipher_DHE_DSS_RC4_SHA1
     , cipher_DHE_RSA_AES128GCM_SHA256
     , cipher_ECDHE_RSA_AES128GCM_SHA256
+    , cipher_ECDHE_RSA_AES128CBC_SHA256
+    , cipher_ECDHE_RSA_AES128CBC_SHA
     ) where
 
 import qualified Data.ByteString as B
@@ -371,6 +373,26 @@ cipher_ECDHE_RSA_AES128GCM_SHA256 = Cipher
     { cipherID           = 0xc02f
     , cipherName         = "ECDHE-RSA-AES128GCM-SHA256"
     , cipherBulk         = bulk_aes128gcm
+    , cipherHash         = SHA256
+    , cipherKeyExchange  = CipherKeyExchange_ECDHE_RSA
+    , cipherMinVer       = Just TLS12 -- RFC 5288 Sec 4
+    }
+
+cipher_ECDHE_RSA_AES128CBC_SHA :: Cipher
+cipher_ECDHE_RSA_AES128CBC_SHA = Cipher
+    { cipherID           = 0xc013
+    , cipherName         = "ECDHE-RSA-AES128CBC-SHA"
+    , cipherBulk         = bulk_aes128
+    , cipherHash         = SHA1
+    , cipherKeyExchange  = CipherKeyExchange_ECDHE_RSA
+    }
+
+--TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256 
+cipher_ECDHE_RSA_AES128CBC_SHA256 :: Cipher
+cipher_ECDHE_RSA_AES128CBC_SHA256 = Cipher
+    { cipherID           = 0xc027
+    , cipherName         = "ECDHE-RSA-AES128CBC-SHA"
+    , cipherBulk         = bulk_aes128
     , cipherHash         = SHA256
     , cipherKeyExchange  = CipherKeyExchange_ECDHE_RSA
     , cipherMinVer       = Just TLS12 -- RFC 5288 Sec 4

--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -1,5 +1,5 @@
 Name:                tls
-Version:             1.3.1
+Version:             1.3.2
 Description:
    Native Haskell TLS and SSL protocol implementation for server and client.
    .


### PR DESCRIPTION
These two are necessary for a variety of near-modern clients on TLS1.0 and TLS1.2.
