### PR TITLE
Remove runPacketNonFlight and Maybe wrappers

### DIFF
--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -76,6 +76,7 @@ import Network.TLS.Parameters
 import Network.TLS.Measurement
 import Network.TLS.Types (Role(..))
 import Network.TLS.Handshake (handshakeClient, handshakeClientWith, handshakeServer, handshakeServerWith)
+import Network.TLS.Handshake.Control (HandshakeSync(..))
 import Network.TLS.PostHandshake (requestCertificateServer, postHandshakeAuthClientWith, postHandshakeAuthServerWith)
 import Network.TLS.X509
 import Network.TLS.RNG
@@ -158,6 +159,8 @@ contextNew backend params = liftIO $ do
     lockRead  <- newMVar ()
     lockState <- newMVar ()
 
+    let syncNoOp _ = return ()
+
     return Context
             { ctxConnection   = getBackend backend
             , ctxShared       = shared
@@ -183,7 +186,7 @@ contextNew backend params = liftIO $ do
             , ctxCertRequests     = crs
             , ctxKeyLogger        = debugKeyLogger debug
             , ctxRecordLayer      = Nothing
-            , ctxHandshakeSync    = Nothing
+            , ctxHandshakeSync    = HandshakeSync syncNoOp syncNoOp
             }
 
 -- | create a new context on an handle.

--- a/core/Network/TLS/Context.hs
+++ b/core/Network/TLS/Context.hs
@@ -72,6 +72,10 @@ import Network.TLS.Struct13
 import Network.TLS.State
 import Network.TLS.Hooks
 import Network.TLS.Record.State
+import Network.TLS.Record.Layer
+import Network.TLS.IO
+import Network.TLS.Sending
+import Network.TLS.Sending13
 import Network.TLS.Parameters
 import Network.TLS.Measurement
 import Network.TLS.Types (Role(..))
@@ -159,9 +163,7 @@ contextNew backend params = liftIO $ do
     lockRead  <- newMVar ()
     lockState <- newMVar ()
 
-    let syncNoOp _ = return ()
-
-    return Context
+    let ctx = Context
             { ctxConnection   = getBackend backend
             , ctxShared       = shared
             , ctxSupported    = supported
@@ -185,9 +187,22 @@ contextNew backend params = liftIO $ do
             , ctxPendingActions   = as
             , ctxCertRequests     = crs
             , ctxKeyLogger        = debugKeyLogger debug
-            , ctxRecordLayer      = Nothing
+            , ctxRecordLayer      = recordLayer
             , ctxHandshakeSync    = HandshakeSync syncNoOp syncNoOp
             }
+
+        syncNoOp _ = return ()
+
+        recordLayer = RecordLayer
+            { recordEncode    = encodeRecord ctx
+            , recordEncode13  = encodeRecord13 ctx
+            , recordSendBytes = sendBytes ctx
+            , recordRecv      = recvRecord ctx
+            , recordRecv13    = recvRecord13 ctx
+            , recordNeedFlush = False
+            }
+
+    return ctx
 
 -- | create a new context on an handle.
 contextNewOnHandle :: (MonadIO m, TLSParams params)

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -132,7 +132,7 @@ data Context = Context
     , ctxCertRequests     :: IORef [Handshake13]  -- ^ pending PHA requests
     , ctxKeyLogger        :: String -> IO ()
     , ctxRecordLayer      :: Maybe RecordLayer
-    , ctxHandshakeSync    :: Maybe HandshakeSync
+    , ctxHandshakeSync    :: HandshakeSync
     }
 
 data Established = NotEstablished

--- a/core/Network/TLS/Context/Internal.hs
+++ b/core/Network/TLS/Context/Internal.hs
@@ -131,7 +131,7 @@ data Context = Context
     , ctxPendingActions   :: IORef [PendingAction]
     , ctxCertRequests     :: IORef [Handshake13]  -- ^ pending PHA requests
     , ctxKeyLogger        :: String -> IO ()
-    , ctxRecordLayer      :: Maybe RecordLayer
+    , ctxRecordLayer      :: RecordLayer
     , ctxHandshakeSync    :: HandshakeSync
     }
 

--- a/core/Network/TLS/Core.hs
+++ b/core/Network/TLS/Core.hs
@@ -327,5 +327,4 @@ updateKey ctx way = liftIO $ do
 
 contextSync :: Context -> ClientStatusI -> IO ()
 contextSync ctx ctl = case ctxHandshakeSync ctx of
-  Nothing                     -> return ()
-  Just (HandshakeSync sync _) -> sync ctl
+    HandshakeSync sync _ -> sync ctl

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -1091,8 +1091,7 @@ postHandshakeAuthClientWith _ _ _ =
 
 contextSync :: Context -> ClientStatusI -> IO ()
 contextSync ctx ctl = case ctxHandshakeSync ctx of
-  Nothing                     -> return ()
-  Just (HandshakeSync sync _) -> sync ctl
+    HandshakeSync sync _ -> sync ctl
 
 quicEarlyData :: ByteString
 quicEarlyData = ""

--- a/core/Network/TLS/Handshake/Client.hs
+++ b/core/Network/TLS/Handshake/Client.hs
@@ -98,7 +98,7 @@ handshakeClient' cparams ctx groups mparams = do
                           usingHState ctx $ setTLS13HandshakeMode HelloRetryRequest
                           clearTxState ctx
                           let cparams' = cparams { clientEarlyData = Nothing }
-                          runPacketFlight ctx [] $ sendChangeCipherSpec13 ctx
+                          runPacketFlight ctx $ sendChangeCipherSpec13 ctx
                           handshakeClient' cparams' ctx [selectedGroup] (Just (crand, clientSession, ver))
                     | otherwise -> throwCore $ Error_Protocol ("server-selected group is not supported", True, IllegalParameter)
                   Just _  -> error "handshakeClient': invalid KeyShare value"
@@ -315,7 +315,7 @@ handshakeClient' cparams ctx groups mparams = do
                 earlyKey <- calculateEarlySecret ctx choice (Right earlySecret) False
                 let ces@(ClientTrafficSecret clientEarlySecret) = pairClient earlyKey
                 when (earlyData /= quicEarlyData) $ do
-                    runPacketFlight ctx [] $ sendChangeCipherSpec13 ctx
+                    runPacketFlight ctx $ sendChangeCipherSpec13 ctx
                     setTxState ctx usedHash usedCipher clientEarlySecret
                     mapChunks_ 16384 (sendPacket13 ctx . AppData13) earlyData
                 -- We set RTT0Sent for QUIC even if earlyData == "".
@@ -870,7 +870,7 @@ handshakeClient13' cparams ctx groupSent choice = do
         recvHandshake13hash ctx $ expectFinished serverHandshakeSecret
         return accext
     hChSf <- transcriptHash ctx
-    runPacketFlight ctx [] $ sendChangeCipherSpec13 ctx
+    runPacketFlight ctx $ sendChangeCipherSpec13 ctx
     let earlyData = clientEarlyData cparams
     when (rtt0accepted && earlyData /= Just quicEarlyData) $
         sendPacket13 ctx (Handshake13 [EndOfEarlyData13])
@@ -1039,7 +1039,7 @@ processCertRequest13 ctx token exts = do
 sendClientFlight13 :: ClientParams -> Context -> Hash -> ByteString -> IO ()
 sendClientFlight13 cparams ctx usedHash baseKey = do
     chain <- clientChain cparams ctx
-    runPacketFlight ctx [] $ do
+    runPacketFlight ctx $ do
         case chain of
             Nothing -> return ()
             Just cc -> usingHState ctx getCertReqToken >>= sendClientData13 cc

--- a/core/Network/TLS/Handshake/Server.hs
+++ b/core/Network/TLS/Handshake/Server.hs
@@ -1196,8 +1196,7 @@ postHandshakeAuthServerWith _ _ _ =
 
 contextSync :: Context -> ServerStatusI -> IO ()
 contextSync ctx ctl = case ctxHandshakeSync ctx of
-  Nothing                     -> return ()
-  Just (HandshakeSync _ sync) -> sync ctl
+    HandshakeSync _ sync -> sync ctl
 
 -- | Max early data size for QUIC.
 quicMaxEarlyDataSize :: Int

--- a/core/Network/TLS/IO.hs
+++ b/core/Network/TLS/IO.hs
@@ -18,8 +18,8 @@ module Network.TLS.IO
     -- * Grouping multiple packets in the same flight
     , PacketFlightM
     , runPacketFlight
-    , runPacketNonFlight
     , loadPacket13
+    , flushFlightIfNeeded
     ) where
 
 import Control.Exception (finally, throwIO)
@@ -277,31 +277,30 @@ type Builder = [ByteString] -> [ByteString]
 newtype PacketFlightM a = PacketFlightM (ReaderT (IORef Builder) IO a)
     deriving (Functor, Applicative, Monad, MonadFail, MonadIO)
 
-runPacketFlight :: Context -> [ByteString] -> PacketFlightM a -> IO a
-runPacketFlight ctx bss0 (PacketFlightM f) = do
+runPacketFlight :: Context -> PacketFlightM a -> IO a
+runPacketFlight ctx (PacketFlightM f) = do
     ref <- newIORef id
-    finally (runReaderT f ref) $ do
-        build <- readIORef ref
-        let bss = bss0 ++ build []
-        unless (null bss) $ contextSendBytes ctx $ B.concat bss
+    finally (runReaderT f ref) $ sendPendingFlight ctx ref
 
-runPacketNonFlight :: Context -> PacketFlightM () -> IO [ByteString]
-runPacketNonFlight ctx (PacketFlightM f) = do
-    ref <- newIORef id
-    runReaderT f ref
+sendPendingFlight :: Context -> IORef Builder -> IO ()
+sendPendingFlight ctx ref = do
     build <- readIORef ref
     let bss = build []
-    case ctxRecordLayer ctx of
-      Nothing -> return bss
-      Just rl -> do
-          RL.sendBytes rl $ B.concat bss
-          return []
+    unless (null bss) $ contextSendBytes ctx $ B.concat bss
 
 loadPacket13 :: Context -> Packet13 -> PacketFlightM ()
 loadPacket13 ctx pkt = PacketFlightM $ do
     bs <- writePacketBytes13 ctx pkt
     ref <- ask
     liftIO $ modifyIORef ref (. (bs :))
+
+-- | The record layer may require to flush the current flight and send pending
+-- packets before changing the Tx key.  This function should be used before each
+-- call to setTxState inside a PacketFlightM computation.
+flushFlightIfNeeded :: Context -> PacketFlightM ()
+flushFlightIfNeeded ctx = PacketFlightM $
+    when (isJust $ ctxRecordLayer ctx) $ ask >>= \ref ->
+        liftIO $ sendPendingFlight ctx ref >> writeIORef ref id
 
 ----------------------------------------------------------------
 

--- a/core/Network/TLS/IO.hs
+++ b/core/Network/TLS/IO.hs
@@ -15,6 +15,10 @@ module Network.TLS.IO
     --
     , isRecvComplete
     , checkValid
+    -- * Record layer primitives
+    , sendBytes
+    , recvRecord
+    , recvRecord13
     -- * Grouping multiple packets in the same flight
     , PacketFlightM
     , runPacketFlight
@@ -37,7 +41,7 @@ import Network.TLS.Packet
 import Network.TLS.Receiving
 import Network.TLS.Receiving13
 import Network.TLS.Record
-import qualified Network.TLS.Record.Layer as RL
+import Network.TLS.Record.Layer
 import Network.TLS.Sending
 import Network.TLS.Sending13
 import Network.TLS.State
@@ -55,9 +59,9 @@ sendPacket ctx pkt = do
     when (isNonNullAppData pkt) $ do
         withEmptyPacket <- liftIO $ readIORef $ ctxNeedEmptyPacket ctx
         when withEmptyPacket $
-            writePacketBytes ctx (AppData B.empty) >>= contextSendBytes ctx
+            writePacketBytes ctx (AppData B.empty) >>= recordSendBytes (ctxRecordLayer ctx)
 
-    writePacketBytes ctx pkt >>= contextSendBytes ctx
+    writePacketBytes ctx pkt >>= recordSendBytes (ctxRecordLayer ctx)
   where isNonNullAppData (AppData b) = not $ B.null b
         isNonNullAppData _           = False
 
@@ -71,7 +75,7 @@ writePacketBytes ctx pkt = do
 ----------------------------------------------------------------
 
 sendPacket13 :: Context -> Packet13 -> IO ()
-sendPacket13 ctx pkt = writePacketBytes13 ctx pkt >>= contextSendBytes ctx
+sendPacket13 ctx pkt = writePacketBytes13 ctx pkt >>= recordSendBytes (ctxRecordLayer ctx)
 
 writePacketBytes13 :: MonadIO m => Context -> Packet13 -> m ByteString
 writePacketBytes13 ctx pkt = do
@@ -115,7 +119,7 @@ recvPacket ctx = liftIO $ do
     -- AppData with maximum size 2^14 + 256.  In all other scenarios and record
     -- types the maximum size is 2^14.
     let appDataOverhead = if hrr then 256 else 0
-    erecord     <- contextRecvRecord ctx compatSSLv2 appDataOverhead
+    erecord <- recordRecv (ctxRecordLayer ctx) compatSSLv2 appDataOverhead
     case erecord of
         Left err     -> return $ Left err
         Right record ->
@@ -142,11 +146,11 @@ recvPacket ctx = liftIO $ do
 -- | recvRecord receive a full TLS record (header + data), from the other side.
 --
 -- The record is disengaged from the record layer
-recvRecord :: Bool    -- ^ flag to enable SSLv2 compat ClientHello reception
+recvRecord :: Context -- ^ TLS context
+           -> Bool    -- ^ flag to enable SSLv2 compat ClientHello reception
            -> Int     -- ^ number of AppData bytes to accept above normal maximum size
-           -> Context -- ^ TLS context
            -> IO (Either TLSError (Record Plaintext))
-recvRecord compatSSLv2 appDataOverhead ctx
+recvRecord ctx compatSSLv2 appDataOverhead
 #ifdef SSLV2_COMPATIBLE
     | compatSSLv2 = readExactBytes ctx 2 >>= either (return . Left) sslv2Header
 #endif
@@ -189,7 +193,7 @@ isEmptyHandshake _                      = False
 
 recvPacket13 :: MonadIO m => Context -> m (Either TLSError Packet13)
 recvPacket13 ctx = liftIO $ do
-    erecord <- contextRecvRecord13 ctx
+    erecord <- recordRecv13 (ctxRecordLayer ctx)
     case erecord of
         Left err@(Error_Protocol (_, True, BadRecordMac)) -> do
             -- If the server decides to reject RTT0 data but accepts RTT1
@@ -286,7 +290,7 @@ sendPendingFlight :: Context -> IORef Builder -> IO ()
 sendPendingFlight ctx ref = do
     build <- readIORef ref
     let bss = build []
-    unless (null bss) $ contextSendBytes ctx $ B.concat bss
+    unless (null bss) $ recordSendBytes (ctxRecordLayer ctx) $ B.concat bss
 
 loadPacket13 :: Context -> Packet13 -> PacketFlightM ()
 loadPacket13 ctx pkt = PacketFlightM $ do
@@ -299,22 +303,5 @@ loadPacket13 ctx pkt = PacketFlightM $ do
 -- call to setTxState inside a PacketFlightM computation.
 flushFlightIfNeeded :: Context -> PacketFlightM ()
 flushFlightIfNeeded ctx = PacketFlightM $
-    when (isJust $ ctxRecordLayer ctx) $ ask >>= \ref ->
+    when (recordNeedFlush $ ctxRecordLayer ctx) $ ask >>= \ref ->
         liftIO $ sendPendingFlight ctx ref >> writeIORef ref id
-
-----------------------------------------------------------------
-
-contextSendBytes :: Context -> ByteString -> IO ()
-contextSendBytes ctx = case ctxRecordLayer ctx of
-  Nothing -> sendBytes ctx
-  Just rl -> RL.sendBytes rl
-
-contextRecvRecord :: Context -> Bool -> Int -> IO (Either TLSError (Record Plaintext))
-contextRecvRecord ctx compatSSLv2 appDataOverhead = case ctxRecordLayer ctx of
-  Nothing -> recvRecord compatSSLv2 appDataOverhead ctx
-  Just rl -> RL.recvRecord rl
-
-contextRecvRecord13 :: Context -> IO (Either TLSError (Record Plaintext))
-contextRecvRecord13 ctx = case ctxRecordLayer ctx of
-  Nothing -> recvRecord13 ctx
-  Just rl -> RL.recvRecord rl

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -96,7 +96,7 @@ newQUICClient cparams = do
     ctx <- contextNew nullBackend cparams
     let ctx' = ctx {
             ctxRecordLayer   = Just rl
-          , ctxHandshakeSync = Just (HandshakeSync sync (\_ -> return ()))
+          , ctxHandshakeSync = HandshakeSync sync (\_ -> return ())
           }
         failed = sync . ClientHandshakeFailedI
     tid <- forkIO $ E.handle failed $ do
@@ -111,7 +111,7 @@ newQUICServer sparams = do
     ctx <- contextNew nullBackend sparams
     let ctx' = ctx {
             ctxRecordLayer   = Just rl
-          , ctxHandshakeSync = Just (HandshakeSync (\_ -> return ()) sync)
+          , ctxHandshakeSync = HandshakeSync (\_ -> return ()) sync
           }
         failed = sync . ServerHandshakeFailedI
     tid <- forkIO $ E.handle failed $ do

--- a/core/Network/TLS/QUIC.hs
+++ b/core/Network/TLS/QUIC.hs
@@ -95,7 +95,7 @@ newQUICClient cparams = do
     (get, put, sync, ask, rl, ref) <- prepare
     ctx <- contextNew nullBackend cparams
     let ctx' = ctx {
-            ctxRecordLayer   = Just rl
+            ctxRecordLayer   = rl
           , ctxHandshakeSync = HandshakeSync sync (\_ -> return ())
           }
         failed = sync . ClientHandshakeFailedI
@@ -110,7 +110,7 @@ newQUICServer sparams = do
     (get, put, sync, ask, rl, ref) <- prepare
     ctx <- contextNew nullBackend sparams
     let ctx' = ctx {
-            ctxRecordLayer   = Just rl
+            ctxRecordLayer   = rl
           , ctxHandshakeSync = HandshakeSync (\_ -> return ()) sync
           }
         failed = sync . ServerHandshakeFailedI

--- a/core/Network/TLS/Record/Layer.hs
+++ b/core/Network/TLS/Record/Layer.hs
@@ -13,19 +13,27 @@ import qualified Control.Exception as E
 import qualified Data.ByteString as B
 
 data RecordLayer = RecordLayer {
-    -- Sending.hs and Sending13.hs
-    encodeRecord :: Record Plaintext -> IO (Either TLSError ByteString)
+    -- Sending.hs
+    recordEncode    :: Record Plaintext -> IO (Either TLSError ByteString)
+
+    -- Sending13.hs
+  , recordEncode13  :: Record Plaintext -> IO (Either TLSError ByteString)
+
     -- IO.hs
-  , sendBytes    :: ByteString -> IO ()
-    -- IO.hs
-  , recvRecord   :: IO (Either TLSError (Record Plaintext))
+  , recordSendBytes :: ByteString -> IO ()
+  , recordRecv      :: Bool -> Int -> IO (Either TLSError (Record Plaintext))
+  , recordRecv13    :: IO (Either TLSError (Record Plaintext))
+  , recordNeedFlush :: Bool
   }
 
 newTransparentRecordLayer :: (ByteString -> IO ()) -> IO ByteString -> RecordLayer
 newTransparentRecordLayer send recv = RecordLayer {
-    encodeRecord = transparentEncodeRecord
-  , sendBytes    = transparentSendBytes send
-  , recvRecord   = transparentRecvRecord recv
+    recordEncode    = transparentEncodeRecord
+  , recordEncode13  = transparentEncodeRecord
+  , recordSendBytes = transparentSendBytes send
+  , recordRecv      = \_ _ -> transparentRecvRecord recv
+  , recordRecv13    = transparentRecvRecord recv
+  , recordNeedFlush = True
   }
 
 transparentEncodeRecord :: Record Plaintext -> IO (Either TLSError ByteString)

--- a/core/Network/TLS/Record/Layer.hs
+++ b/core/Network/TLS/Record/Layer.hs
@@ -50,6 +50,5 @@ transparentSendBytes _    "" = return ()
 transparentSendBytes send bs = send bs
 
 transparentRecvRecord :: IO ByteString -> IO (Either TLSError (Record Plaintext))
-transparentRecvRecord recv = do
-    bs <- recv
-    return $ Right $ Record ProtocolType_Handshake TLS12 (fragmentPlaintext bs)
+transparentRecvRecord recv =
+    Right . Record ProtocolType_Handshake TLS12 . fragmentPlaintext <$> recv

--- a/core/Network/TLS/Sending.hs
+++ b/core/Network/TLS/Sending.hs
@@ -10,6 +10,7 @@
 --
 module Network.TLS.Sending (
     encodePacket
+  , encodeRecord
   , encodeRecordM
   , updateHandshake
   ) where
@@ -22,7 +23,7 @@ import Network.TLS.Imports
 import Network.TLS.Packet
 import Network.TLS.Parameters
 import Network.TLS.Record
-import qualified Network.TLS.Record.Layer as RL
+import Network.TLS.Record.Layer
 import Network.TLS.State
 import Network.TLS.Struct
 import Network.TLS.Types (Role(..))
@@ -41,7 +42,7 @@ encodePacket ctx pkt = do
     let pt = packetType pkt
         mkRecord bs = Record pt ver (fragmentPlaintext bs)
     records <- map mkRecord <$> packetToFragments ctx 16384 pkt
-    bs <- fmap B.concat <$> forEitherM records (contextEncodeRecord ctx)
+    bs <- fmap B.concat <$> forEitherM records (recordEncode $ ctxRecordLayer ctx)
     when (pkt == ChangeCipherSpec) $ switchTxEncryption ctx
     return bs
 
@@ -102,8 +103,3 @@ updateHandshake ctx role hs = do
     return encoded
   where
     encoded = encodeHandshake hs
-
-contextEncodeRecord :: Context -> Record Plaintext -> IO (Either TLSError ByteString)
-contextEncodeRecord ctx = case ctxRecordLayer ctx of
-  Nothing -> encodeRecord ctx
-  Just rl -> RL.encodeRecord rl

--- a/core/Network/TLS/Sending13.hs
+++ b/core/Network/TLS/Sending13.hs
@@ -10,6 +10,7 @@
 --
 module Network.TLS.Sending13
        ( encodePacket13
+       , encodeRecord13
        , updateHandshake13
        ) where
 
@@ -21,7 +22,7 @@ import Network.TLS.Imports
 import Network.TLS.Packet
 import Network.TLS.Packet13
 import Network.TLS.Record
-import qualified Network.TLS.Record.Layer as RL
+import Network.TLS.Record.Layer
 import Network.TLS.Sending
 import Network.TLS.Struct
 import Network.TLS.Struct13
@@ -34,13 +35,13 @@ encodePacket13 ctx pkt = do
     let pt = contentType pkt
         mkRecord bs = Record pt TLS12 (fragmentPlaintext bs)
     records <- map mkRecord <$> packetToFragments ctx 16384 pkt
-    fmap B.concat <$> forEitherM records (contextEncodeRecord ctx)
+    fmap B.concat <$> forEitherM records (recordEncode13 $ ctxRecordLayer ctx)
 
 prepareRecord :: Context -> RecordM a -> IO (Either TLSError a)
 prepareRecord = runTxState
 
-encodeRecord :: Context -> Record Plaintext -> IO (Either TLSError ByteString)
-encodeRecord ctx = prepareRecord ctx . encodeRecordM
+encodeRecord13 :: Context -> Record Plaintext -> IO (Either TLSError ByteString)
+encodeRecord13 ctx = prepareRecord ctx . encodeRecordM
 
 packetToFragments :: Context -> Int -> Packet13 -> IO [ByteString]
 packetToFragments ctx len (Handshake13 hss)  =
@@ -66,8 +67,3 @@ updateHandshake13 ctx hs
     isIgnored NewSessionTicket13{} = True
     isIgnored KeyUpdate13{}        = True
     isIgnored _                    = False
-
-contextEncodeRecord :: Context -> Record Plaintext -> IO (Either TLSError ByteString)
-contextEncodeRecord ctx = case ctxRecordLayer ctx of
-  Nothing -> encodeRecord ctx
-  Just rl -> RL.encodeRecord rl


### PR DESCRIPTION
The logic with `runPacketNonFlight` is difficult to understand and does not hide the encoded packets anymore. The same result can be achieved by flushing the packets conditionally.

It's also possible to refactor the code to eliminate the Maybe wrappers added to ctxRecordLayer and ctxHandshakeSync. The lambdas are called also for the native (non-QUIC) code.