### PR TITLE
Point `.cabal` file to the current repo

### DIFF
--- a/core/tls.cabal
+++ b/core/tls.cabal
@@ -7,7 +7,7 @@ copyright:          Vincent Hanquez <vincent@snarc.org>
 maintainer:         Kazu Yamamoto <kazu@iij.ad.jp>
 author:             Vincent Hanquez <vincent@snarc.org>
 stability:          experimental
-homepage:           http://github.com/vincenthz/hs-tls
+homepage:           https://github.com/kazu-yamamoto/hs-tls
 synopsis:           TLS/SSL protocol native implementation (Server and Client)
 description:
     Native Haskell TLS and SSL protocol implementation for server and client.
@@ -31,7 +31,7 @@ extra-source-files:
 
 source-repository head
     type:     git
-    location: https://github.com/vincenthz/hs-tls
+    location: https://github.com/kazu-yamamoto/hs-tls
     subdir:   core
 
 flag compat


### PR DESCRIPTION
Feel free to close this as incorrect if it is incorrect, but my understanding is that this repo is the repo where this is now maintained? Would have saved me a bit of searching to figure out where to submit #4 :)